### PR TITLE
[WOWME-27] 실제 README에서 파비콘 이미지가 안 뜨는 현상

### DIFF
--- a/src/services/blog.service.ts
+++ b/src/services/blog.service.ts
@@ -1,3 +1,4 @@
+import logger from "@config/logger.config";
 import GetRecentBlogCardParamDTO from "@dto/blog/get-recent-blog-card.param.dto";
 import GetRecentBlogCardResponseDTO from "@dto/blog/get-recent-blog-card.response.dto";
 import GetRecentBlogUrlParamDTO from "@dto/blog/get-recent-blog-url.param.dto";
@@ -46,7 +47,7 @@ export class BlogService implements IBlogService {
       throw new CError("No posts found in the RSS feed", HTTP_STATUS_CODE.BAD_REQUEST);
     }
 
-    const postData = this.extractPostData(latestPost, feed, url);
+    const postData = await this.extractPostData(latestPost, feed, url);
     const svg = generateBlogCardSVG(postData, theme);
 
     return new GetRecentBlogCardResponseDTO(svg);
@@ -77,17 +78,13 @@ export class BlogService implements IBlogService {
   }
 
   /**
-   * @description 파비콘 URL 생성
-   */
-  private createFaviconUrl(url: string): string {
-    const urlObj = new URL(url);
-    return `https://www.google.com/s2/favicons?domain=${urlObj.origin}`;
-  }
-
-  /**
    * @description 블로그 카드 데이터로 변환
    */
-  private extractPostData(post: Parser.Item, feed: Parser.Output<Parser.Item>, url: string): BlogCardData {
+  private async extractPostData(
+    post: Parser.Item,
+    feed: Parser.Output<Parser.Item>,
+    url: string,
+  ): Promise<BlogCardData> {
     const postTitle = post.title || "";
     const blogName = (feed as { subtitle?: string } & Parser.Output<Parser.Item>).subtitle || feed.title || "";
     const tags = post.categories || [];
@@ -110,15 +107,33 @@ export class BlogService implements IBlogService {
         })
       : "";
 
-    const faviconUrl = this.createFaviconUrl(url);
+    const faviconBuffer = await this.getFaviconBuffer(url);
 
     return {
       blogName,
       date,
       description,
-      faviconUrl,
+      faviconBuffer,
       postTitle,
       tags,
     };
+  }
+
+  /**
+   * @description 파비콘 버퍼 가져오기
+   */
+  private async getFaviconBuffer(url: string): Promise<ArrayBuffer> {
+    try {
+      const urlObj = new URL(url);
+
+      const faviconUrl = `https://www.google.com/s2/favicons?domain=${urlObj.origin}`;
+      const faviconRes = await fetch(faviconUrl);
+      const buffer = await faviconRes.arrayBuffer();
+
+      return buffer;
+    } catch (error) {
+      logger.error(error);
+      return new ArrayBuffer(0);
+    }
   }
 }

--- a/src/templates/blog-card.template.ts
+++ b/src/templates/blog-card.template.ts
@@ -5,7 +5,7 @@ export interface BlogCardData {
   blogName: string;
   date: string;
   description: string;
-  faviconUrl: string;
+  faviconBuffer: ArrayBuffer;
   postTitle: string;
   tags: string[];
 }
@@ -39,7 +39,7 @@ const DARK_THEME: ThemeColors = {
  * @param theme - undefined일 경우 브라우저의 prefers-color-scheme 사용
  */
 export function generateBlogCardSVG(data: BlogCardData, theme?: Theme): string {
-  const { blogName, date, description, faviconUrl, postTitle, tags } = data;
+  const { blogName, date, description, faviconBuffer, postTitle, tags } = data;
 
   // 스타일 생성
   let styleContent = "";
@@ -104,12 +104,31 @@ export function generateBlogCardSVG(data: BlogCardData, theme?: Theme): string {
     })
     .filter((el) => el !== "");
 
+  /* 파비콘 처리 영역 */
+  const hasFavicon = faviconBuffer.byteLength > 0;
+  const faviconBase64 = hasFavicon ? Buffer.from(faviconBuffer).toString("base64") : "";
+  const blogNameX = hasFavicon ? 402 : 430; // 파비콘이 있을 때 블로그명을 오른쪽으로 이동
+
+  const faviconClipPath = hasFavicon
+    ? `<defs>
+      <clipPath id="faviconClip">
+        <circle cx="420" cy="131" r="8"/>
+      </clipPath>
+      </defs>
+    `
+    : "";
+
+  const faviconElements = hasFavicon
+    ? `
+  <!-- 파비콘 배경 (원형) -->
+  <circle cx="420" cy="131" r="8" fill="#ffffff" stroke="var(--border-color)" stroke-width="1"/>
+  
+  <!-- 파비콘 -->
+  <image x="412" y="123" width="16" height="16" href="data:image/png;base64,${faviconBase64}" clip-path="url(#faviconClip)"/>`
+    : "";
+
   return `<svg width="450" height="150" viewBox="0 0 450 150" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <defs>
-    <clipPath id="faviconClip">
-      <circle cx="420" cy="131" r="8"/>
-    </clipPath>
-  </defs>
+  ${faviconClipPath}
   ${styleContent}
   
   <!-- 배경 -->
@@ -153,14 +172,9 @@ export function generateBlogCardSVG(data: BlogCardData, theme?: Theme): string {
   </text>
   
   <!-- 블로그명 -->
-  <text x="402" y="135" font-size="12" font-weight="400" fill="var(--text-color)" text-anchor="end">
+  <text x="${blogNameX}" y="135" font-size="12" font-weight="400" fill="var(--text-color)" text-anchor="end">
     ${escapeXml(blogName)}
   </text>
-  
-  <!-- 파비콘 배경 (원형) -->
-  <circle cx="420" cy="131" r="8" fill="#ffffff" stroke="var(--border-color)" stroke-width="1"/>
-  
-  <!-- 파비콘 -->
-  <image x="412" y="123" width="16" height="16" xlink:href="${faviconUrl}" clip-path="url(#faviconClip)"/>
+  ${faviconElements}
 </svg>`;
 }


### PR DESCRIPTION
### **User description**
자동 생성된 PR입니다.
- 지라이슈: WOWME-27


___

### **PR Type**
Bug fix


___

### **Description**
- 파비콘을 URL 대신 ArrayBuffer로 처리하여 실제 환경에서 표시되도록 개선

- 파비콘 로드 실패 시 빈 버퍼 반환하여 안전하게 처리

- 파비콘 존재 여부에 따라 블로그명 위치 동적 조정

- 비동기 파비콘 처리를 위해 extractPostData 메서드를 async로 변경


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["파비콘 URL 생성"] --> B["ArrayBuffer로 변환"]
  B --> C["Base64 인코딩"]
  C --> D["SVG에 임베드"]
  E["에러 발생"] --> F["빈 버퍼 반환"]
  B --> F
  D --> G["파비콘 표시 또는 숨김"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blog.service.ts</strong><dd><code>파비콘을 URL에서 버퍼로 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/blog.service.ts

<ul><li><code>logger</code> 임포트 추가하여 에러 로깅 지원<br> <li> <code>extractPostData</code> 메서드를 비동기로 변경하고 await 처리<br> <li> <code>createFaviconUrl</code> 메서드 제거<br> <li> 새로운 <code>getFaviconBuffer</code> 비동기 메서드 추가로 파비콘을 ArrayBuffer로 반환<br> <li> 파비콘 로드 실패 시 빈 ArrayBuffer 반환하여 에러 처리</ul>


</details>


  </td>
  <td><a href="https://github.com/gingaminga/blog-readme-stats/pull/10/files#diff-d631048f9da337699f5b288b5bec804d4ff2414296b363cb3897ee65ab6ea4bb">+27/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blog-card.template.ts</strong><dd><code>파비콘 버퍼 처리 및 조건부 렌더링 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/templates/blog-card.template.ts

<ul><li><code>BlogCardData</code> 인터페이스에서 <code>faviconUrl</code> 문자열을 <code>faviconBuffer</code> ArrayBuffer로 변경<br> <li> 파비콘 존재 여부를 확인하는 로직 추가 (<code>hasFavicon</code> 변수)<br> <li> ArrayBuffer를 Base64로 인코딩하여 SVG에 임베드<br> <li> 파비콘 존재 여부에 따라 블로그명 X 좌표 동적 조정<br> <li> 파비콘이 없을 때 관련 SVG 요소를 조건부로 렌더링하여 불필요한 마크업 제거</ul>


</details>


  </td>
  <td><a href="https://github.com/gingaminga/blog-readme-stats/pull/10/files#diff-328667dcd1f7ba193de5aabf350658ea332b5d387864b7264e3d903b68dd4c66">+28/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

