### PR TITLE
[WOWME-29] 그려질 때 애니메이션 추가하기

### DIFF
--- a/src/templates/blog-card.template.ts
+++ b/src/templates/blog-card.template.ts
@@ -57,6 +57,19 @@ export function generateBlogCardSVG(data: BlogCardData, theme?: Theme): string {
         --tag-bg: ${colors.tagBgColor};
       }
       ${tagOpacity}
+      
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+      
+      .card-container {
+        animation: fadeIn 0.6s ease-out;
+      }
     </style>`;
   } else {
     // 테마가 없는 경우: 브라우저 설정에 따라 자동 변경
@@ -82,6 +95,19 @@ export function generateBlogCardSVG(data: BlogCardData, theme?: Theme): string {
         .tag-bg {
           fill-opacity: 0.7;
         }
+      }
+      
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+      
+      .card-container {
+        animation: fadeIn 0.6s ease-out;
       }
     </style>`;
   }
@@ -131,50 +157,52 @@ export function generateBlogCardSVG(data: BlogCardData, theme?: Theme): string {
   ${faviconClipPath}
   ${styleContent}
   
-  <!-- 배경 -->
-  <rect width="450" height="150" fill="var(--bg-color)" stroke="var(--border-color)" stroke-width="1" rx="10"/>
-  
-  <!-- 제목 -->
-  <foreignObject x="20" y="15" width="410" height="30">
-    <div xmlns="http://www.w3.org/1999/xhtml" style="
-      font-size: 20px;
-      font-weight: 700;
-      color: var(--text-color);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      width: 100%;
-      height: 100%;
-    ">${escapeXml(postTitle)}</div>
-  </foreignObject>
-  
-  <!-- 설명 (최대 2줄) -->
-  <foreignObject x="20" y="45" width="410" height="40">
-    <div xmlns="http://www.w3.org/1999/xhtml" style="
-      font-size: 12px;
-      font-weight: 400;
-      color: var(--description-color);
-      overflow: hidden;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      line-height: 1.6;
-      width: 100%;
-    ">${escapeXml(description)}</div>
-  </foreignObject>
-  
-  <!-- 태그 -->
-  ${tagElements.join("")}
-  
-  <!-- 작성 날짜 -->
-  <text x="20" y="135" font-size="12" font-weight="400" fill="var(--text-color)">
-    ${escapeXml(date)}
-  </text>
-  
-  <!-- 블로그명 -->
-  <text x="${blogNameX}" y="135" font-size="12" font-weight="400" fill="var(--text-color)" text-anchor="end">
-    ${escapeXml(blogName)}
-  </text>
-  ${faviconElements}
+  <g class="card-container">
+    <!-- 배경 -->
+    <rect width="450" height="150" fill="var(--bg-color)" stroke="var(--border-color)" stroke-width="1" rx="10"/>
+    
+    <!-- 제목 -->
+    <foreignObject x="20" y="15" width="410" height="30">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="
+        font-size: 20px;
+        font-weight: 700;
+        color: var(--text-color);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 100%;
+        height: 100%;
+      ">${escapeXml(postTitle)}</div>
+    </foreignObject>
+    
+    <!-- 설명 (최대 2줄) -->
+    <foreignObject x="20" y="45" width="410" height="40">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="
+        font-size: 12px;
+        font-weight: 400;
+        color: var(--description-color);
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        line-height: 1.6;
+        width: 100%;
+      ">${escapeXml(description)}</div>
+    </foreignObject>
+    
+    <!-- 태그 -->
+    ${tagElements.join("")}
+    
+    <!-- 작성 날짜 -->
+    <text x="20" y="135" font-size="12" font-weight="400" fill="var(--text-color)">
+      ${escapeXml(date)}
+    </text>
+    
+    <!-- 블로그명 -->
+    <text x="${blogNameX}" y="135" font-size="12" font-weight="400" fill="var(--text-color)" text-anchor="end">
+      ${escapeXml(blogName)}
+    </text>
+    ${faviconElements}
+  </g>
 </svg>`;
 }


### PR DESCRIPTION
### **User description**
자동 생성된 PR입니다.
- 지라이슈: WOWME-29


___

### **PR Type**
Enhancement


___

### **Description**
- 블로그 카드 렌더링 시 페이드인 애니메이션 추가

- CSS `@keyframes fadeIn` 정의 (0.6초 ease-out)

- SVG 콘텐츠를 `<g class="card-container">` 그룹으로 래핑

- 라이트/다크 테마 모두에 애니메이션 적용


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSS 스타일"] -->|fadeIn 키프레임 추가| B["애니메이션 정의"]
  C["SVG 콘텐츠"] -->|card-container 그룹 래핑| D["애니메이션 적용"]
  B -->|0.6s ease-out| D
  D -->|자연스러운 렌더링| E["완성된 카드"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blog-card.template.ts</strong><dd><code>페이드인 애니메이션 추가 및 SVG 구조 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/templates/blog-card.template.ts

<ul><li><code>@keyframes fadeIn</code> 애니메이션 정의 추가 (라이트 테마 섹션)<br> <li> <code>.card-container</code> 클래스에 <code>animation: fadeIn 0.6s ease-out</code> 적용<br> <li> 다크 테마 섹션에도 동일한 애니메이션 정의 추가<br> <li> 모든 SVG 콘텐츠를 <code><g class="card-container"></code> 요소로 감싸기</ul>


</details>


  </td>
  <td><a href="https://github.com/gingaminga/blog-readme-stats/pull/12/files#diff-328667dcd1f7ba193de5aabf350658ea332b5d387864b7264e3d903b68dd4c66">+73/-45</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

