### PR TITLE
[WOWME-28] 다크모드에서 테두리 영역을 뚜렷하게 표시하기

### DIFF
--- a/src/templates/blog-card.template.ts
+++ b/src/templates/blog-card.template.ts
@@ -28,7 +28,7 @@ const LIGHT_THEME: ThemeColors = {
 
 const DARK_THEME: ThemeColors = {
   bgColor: "#202830",
-  borderColor: "#202830",
+  borderColor: "#000000",
   descriptionColor: "#959595",
   tagBgColor: "#6366F1",
   textColor: "#F9FAFB",


### PR DESCRIPTION
### **User description**
자동 생성된 PR입니다.
- 지라이슈: WOWME-28


___

### **PR Type**
Bug fix


___

### **Description**
- 다크테마에서 블로그 카드 테두리 색상을 검은색으로 변경

- 배경색과 동일한 테두리 색상으로 인한 가시성 문제 해결


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["다크테마 테두리 색상"] -- "변경" --> B["#202830에서 #000000으로"]
  B -- "결과" --> C["테두리 영역 뚜렷하게 표시"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blog-card.template.ts</strong><dd><code>다크테마 테두리 색상 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/templates/blog-card.template.ts

<ul><li><code>DARK_THEME</code> 객체의 <code>borderColor</code> 값을 <code>#202830</code>에서 <code>#000000</code>으로 변경<br> <li> 다크모드에서 배경색과 구분되는 테두리 색상으로 가시성 개선</ul>


</details>


  </td>
  <td><a href="https://github.com/gingaminga/blog-readme-stats/pull/13/files#diff-328667dcd1f7ba193de5aabf350658ea332b5d387864b7264e3d903b68dd4c66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

