### PR TITLE
[WOWME-32] 일부 플랫폼에서 파비콘이 노출되지 않는 현상

### DIFF
--- a/src/services/blog.service.ts
+++ b/src/services/blog.service.ts
@@ -121,7 +121,7 @@ export class BlogService implements IBlogService {
   private async getFaviconBuffer(url?: string): Promise<ArrayBuffer> {
     try {
       if (!url) {
-        throw new Error("URL is undefined.");
+        return new ArrayBuffer(0);
       }
 
       const faviconUrl = `https://www.google.com/s2/favicons?domain=${url}`;


### PR DESCRIPTION
### **User description**
자동 생성된 PR입니다.
- 지라이슈: WOWME-32


___

### **PR Type**
Bug fix


___

### **Description**
- 파비콘 URL로 원본 링크 대신 피드 링크 사용

- Google Favicon API에 origin 대신 전체 URL 전달

- 불필요한 URL 파라미터 제거 및 에러 처리 개선


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RSS 피드 파싱"] -->|"피드 링크 추출"| B["extractPostData 호출"]
  B -->|"feed.link 전달"| C["getFaviconBuffer"]
  C -->|"전체 URL 사용"| D["Google Favicon API"]
  D -->|"파비콘 반환"| E["블로그 카드 생성"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blog.service.ts</strong><dd><code>파비콘 조회 로직 개선 및 URL 처리 최적화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/blog.service.ts

<ul><li><code>extractPostData</code> 메서드에서 불필요한 <code>url</code> 파라미터 제거<br> <li> <code>getFaviconBuffer</code> 호출 시 원본 URL 대신 <code>feed.link</code> 전달<br> <li> <code>getFaviconBuffer</code>에서 <code>urlObj.origin</code> 대신 전체 URL 사용하여 플랫폼별 파비콘 정확도 향상<br> <li> URL 검증 실패 시 빈 ArrayBuffer 반환으로 에러 처리 개선</ul>


</details>


  </td>
  <td><a href="https://github.com/gingaminga/blog-readme-stats/pull/16/files#diff-d631048f9da337699f5b288b5bec804d4ff2414296b363cb3897ee65ab6ea4bb">+8/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

